### PR TITLE
docker-based testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Set up ArangoDB Instance via Docker
-      - run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=opensesame arangodb/arangodb:3.9.1
+        run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=opensesame arangodb/arangodb:3.9.1
       - name: Start ArangoDB Instance
-      - run: docker start adb
+        run: docker start adb
       - name: Setup pip
         run: python -m pip install --upgrade pip setuptools wheel
       - name: Install packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,8 @@ jobs:
         run: flake8 ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run isort
         run: isort --check --profile=black ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
-      # - name: Run mypy
-      #   run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
+      - name: Run mypy
+        run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run pytest
         run: py.test --cov=${{env.PACKAGE_DIR}} --cov-report xml -v --color=yes --no-cov-on-fail --code-highlight=yes
       - name: Publish to coveralls.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,8 @@ jobs:
         run: flake8 ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run isort
         run: isort --check --profile=black ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
-      - name: Run mypy
-        run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
+      # - name: Run mypy
+      #   run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run pytest
         run: py.test --cov=${{env.PACKAGE_DIR}} --cov-report xml -v --color=yes --no-cov-on-fail --code-highlight=yes
       - name: Publish to coveralls.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: Set up ArangoDB Instance via Docker
+      - run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=opensesame arangodb/arangodb:3.9.1
+      - name: Start ArangoDB Instance
+      - run: docker start adb
       - name: Setup pip
         run: python -m pip install --upgrade pip setuptools wheel
       - name: Install packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Set up ArangoDB Instance via Docker
-        run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=opensesame arangodb/arangodb:3.9.1
+        run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=openSesame arangodb/arangodb:3.9.1
       - name: Start ArangoDB Instance
         run: docker start adb
       - name: Setup pip

--- a/README.md
+++ b/README.md
@@ -83,11 +83,22 @@ adb_karate_graph = adbdgl_adapter.dgl_to_arangodb("Karate", karate_dgl_g)
 
 ##  Development & Testing
 
-Prerequisite: `arangorestore` must be installed
+Prerequisite: `arangorestore`
 
 1. `git clone https://github.com/arangoml/dgl-adapter.git`
 2. `cd dgl-adapter`
-3. `python -m venv .venv`
-4. `source .venv/bin/activate` (MacOS) or `.venv/scripts/activate` (Windows)
+3. (create virtual environment of choice)
 5. `pip install -e . pytest`
-6. `pytest`
+6. `docker run -p 8529:8529 -e ARANGO_ROOT_PASSWORD=opensesame arangodb/arangodb:3.9.1` (optional if not already active)
+7. `pytest --host localhost --port 8529 --password opensesame`
+
+Note: You can run the set of tests on any ArangoDB endpoint via the following command-line options:
+```python
+def pytest_addoption(parser):
+    parser.addoption("--protocol", action="store", default="http")
+    parser.addoption("--host", action="store", default="localhost")
+    parser.addoption("--port", action="store", default="8529")
+    parser.addoption("--dbName", action="store", default="_system")
+    parser.addoption("--username", action="store", default="root")
+    parser.addoption("--password", action="store", default="opensesame")
+```

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ from dgl.data import KarateClubDataset
 # Store ArangoDB endpoint connection info
 # Assumption: the ArangoDB "fraud detection" dataset is imported to this endpoint for example purposes
 con = {
-    "hostname": "localhost",
     "protocol": "http",
+    "hostname": "localhost",
     "port": 8529,
     "username": "root",
-    "password": "rootpassword",
+    "password": "openSesame",
     "dbName": "_system",
 }
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,15 @@ The Deep Graph Library (DGL) is an easy-to-use, high performance and scalable Py
 * [Documentation](https://docs.dgl.ai/)
 * [Highlighted Features](https://github.com/dmlc/dgl#highlighted-features)
 
+## Installation
+
+```
+pip install adbdgl-adapter
+```
+
 ##  Quickstart
 
-Get Started on Colab: <a href="https://colab.research.google.com/github/arangoml/dgl-adapter/blob/master/examples/ArangoDB_DGL_Adapter.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+For a more detailed walk-through, access the official notebook on Colab: <a href="https://colab.research.google.com/github/arangoml/dgl-adapter/blob/master/examples/ArangoDB_DGL_Adapter.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
 
 ```py
@@ -39,8 +45,8 @@ from adbdgl_adapter.adapter import ADBDGL_Adapter
 # Import a sample graph from DGL
 from dgl.data import KarateClubDataset
 
-# This is the connection information for your ArangoDB instance
-# (Let's assume that the ArangoDB fraud-detection data dump is imported to this endpoint)
+# Store ArangoDB endpoint connection info
+# Assumption: the ArangoDB "fraud detection" dataset is imported to this endpoint for example purposes
 con = {
     "hostname": "localhost",
     "protocol": "http",
@@ -50,20 +56,20 @@ con = {
     "dbName": "_system",
 }
 
-# This instantiates your ADBDGL Adapter with your connection credentials
+# Instantiate the ADBDGL Adapter with connection credentials
 adbdgl_adapter = ADBDGL_Adapter(con)
 
-# ArangoDB to DGL via Graph
+# Convert ArangoDB to DGL via Graph Name
 dgl_fraud_graph = adbdgl_adapter.arangodb_graph_to_dgl("fraud-detection")
 
-# ArangoDB to DGL via Collections
+# Convert ArangoDB to DGL via Collection Names
 dgl_fraud_graph_2 = adbdgl_adapter.arangodb_collections_to_dgl(
         "fraud-detection", 
         {"account", "Class", "customer"}, # Specify vertex collections
         {"accountHolder", "Relationship", "transaction"}, # Specify edge collections
 )
 
-# ArangoDB to DGL via Metagraph
+# Convert ArangoDB to DGL via a Metagraph
 metagraph = {
     "vertexCollections": {
         "account": {"Balance", "account_type", "customer_id", "rank"},
@@ -76,9 +82,9 @@ metagraph = {
 }
 dgl_fraud_graph_3 = adbdgl_adapter.arangodb_to_dgl("fraud-detection", metagraph)
 
-# DGL to ArangoDB
+# Convert DGL to ArangoDB
 dgl_karate_graph = KarateClubDataset()[0]
-adb_karate_graph = adbdgl_adapter.dgl_to_arangodb("Karate", karate_dgl_g)
+adb_karate_graph = adbdgl_adapter.dgl_to_arangodb("Karate", dgl_karate_graph)
 ```
 
 ##  Development & Testing
@@ -88,11 +94,11 @@ Prerequisite: `arangorestore`
 1. `git clone https://github.com/arangoml/dgl-adapter.git`
 2. `cd dgl-adapter`
 3. (create virtual environment of choice)
-5. `pip install -e . pytest`
-6. `docker run -p 8529:8529 -e ARANGO_ROOT_PASSWORD=opensesame arangodb/arangodb:3.9.1` (optional if not already active)
-7. `pytest --host localhost --port 8529 --password opensesame`
+4. `pip install -e . pytest`
+5. (create an ArangoDB instance with method of choice)
+6. `pytest --protocol <> --host <> --port <> --dbName <> --username <> --password <>`
 
-Note: You can run the set of tests on any ArangoDB endpoint via the following command-line options:
+**Note** Parameters can be omitted if the endpoint uses the default values specified below:
 ```python
 def pytest_addoption(parser):
     parser.addoption("--protocol", action="store", default="http")
@@ -100,5 +106,5 @@ def pytest_addoption(parser):
     parser.addoption("--port", action="store", default="8529")
     parser.addoption("--dbName", action="store", default="_system")
     parser.addoption("--username", action="store", default="root")
-    parser.addoption("--password", action="store", default="opensesame")
+    parser.addoption("--password", action="store", default="openSesame")
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Prerequisite: `arangorestore`
 5. (create an ArangoDB instance with method of choice)
 6. `pytest --protocol <> --host <> --port <> --dbName <> --username <> --password <>`
 
-**Note** Parameters can be omitted if the endpoint uses the default values specified below:
+**Note**: A `pytest` parameter can be omitted if the endpoint is using its default value:
 ```python
 def pytest_addoption(parser):
     parser.addoption("--protocol", action="store", default="http")

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -12,7 +12,7 @@ from arango.result import Result
 from dgl import DGLGraph, heterograph
 from dgl.heterograph import DGLHeteroGraph
 from dgl.view import HeteroEdgeDataView, HeteroNodeDataView
-from torch import tensor  # type: ignore
+from torch import tensor
 from torch.functional import Tensor
 
 from .abc import Abstract_ADBDGL_Adapter

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Set, Union
 
 from arango import ArangoClient
+from arango.database import StandardDatabase
 from arango.cursor import Cursor
 from arango.graph import Graph as ArangoDBGraph
 from arango.result import Result
@@ -54,6 +55,9 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
         print(f"Connecting to {url}")
         self.__db = ArangoClient(hosts=url).db(db_name, username, password, verify=True)
         self.__cntrl: ADBDGL_Controller = controller
+
+    def db(self) -> StandardDatabase:
+        return self.__db
 
     def arangodb_to_dgl(
         self, name: str, metagraph: ArangoMetagraph, **query_options: Any

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Set, Union
 
 from arango import ArangoClient
-from arango.database import StandardDatabase
 from arango.cursor import Cursor
+from arango.database import StandardDatabase
 from arango.graph import Graph as ArangoDBGraph
 from arango.result import Result
 from dgl import DGLGraph, heterograph

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,5 +27,6 @@ extend-ignore = E203, E741, W503
 exclude =.git .idea .*_cache dist venv
 
 [mypy]
-ignore_missing_imports = True
 strict = True
+ignore_missing_imports = True
+implicit_reexport = True

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup(
     python_requires=">=3.6",
     license="Apache Software License",
     install_requires=[
-        "python-arango==7.3.0",
-        "torch==1.10.0",
         "dgl==0.6.1",
+        "torch==1.11.0",
+        "python-arango==7.3.3",
         "setuptools>=42",
         "setuptools_scm[toml]>=3.4",
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "dgl==0.6.1",
         "torch==1.11.0",
-        "python-arango==7.3.3",
+        "python-arango==7.3.1",
         "setuptools>=42",
         "setuptools_scm[toml]>=3.4",
     ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     license="Apache Software License",
     install_requires=[
         "dgl==0.6.1",
-        "torch==1.11.0",
+        "torch==1.10.2",
         "python-arango==7.3.1",
         "setuptools>=42",
         "setuptools_scm[toml]>=3.4",

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
     license="Apache Software License",
     install_requires=[
         "dgl==0.6.1",
-        "torch==1.10.2",
-        "python-arango==7.3.1",
+        "torch>=1.10.2",
+        "python-arango>=7.3.1",
         "setuptools>=42",
         "setuptools_scm[toml]>=3.4",
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from dgl import DGLGraph, remove_self_loop
 from dgl.data import KarateClubDataset, MiniGCDataset
-from requests import post
 from torch import ones, rand, tensor, zeros
 
 from adbdgl_adapter.adapter import ADBDGL_Adapter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,8 @@ from typing import Any
 
 from dgl import DGLGraph, remove_self_loop
 from dgl.data import KarateClubDataset, MiniGCDataset
-from torch import ones, rand, tensor, zeros  # type: ignore
+from requests import post
+from torch import ones, rand, tensor, zeros
 
 from adbdgl_adapter.adapter import ADBDGL_Adapter
 from adbdgl_adapter.typings import Json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ def pytest_configure(config: Any) -> None:
         ],
     )
 
+
 def arango_restore(con: Json, path_to_data: str) -> None:
     restore_prefix = "./assets/" if os.getenv("GITHUB_ACTIONS") else ""
 
@@ -78,6 +79,7 @@ def arango_restore(con: Json, path_to_data: str) -> None:
         cwd=f"{PROJECT_DIR}/tests",
         shell=True,
     )
+
 
 def get_karate_graph() -> DGLGraph:
     return KarateClubDataset()[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,17 +46,7 @@ def pytest_configure(config: Any) -> None:
     adbdgl_adapter = ADBDGL_Adapter(con)
 
     # Restore fraud dataset via arangorestore
-    arango_restore_data_path = "examples/data/fraud_dump"
-    restore_prefix = "./assets/" if os.getenv("GITHUB_ACTIONS") else ""
-    subprocess.check_call(
-        f'chmod -R 755 ./assets/arangorestore && {restore_prefix}arangorestore \
-            -c none --server.endpoint tcp://{con["hostname"]}:{con["port"]} \
-                --server.username {con["username"]} --server.database {con["dbName"]} \
-                    --server.password {con["password"]} \
-                        --input-directory "{PROJECT_DIR}/{arango_restore_data_path}"',
-        cwd=f"{PROJECT_DIR}/tests",
-        shell=True,
-    )
+    arango_restore(con, "examples/data/fraud_dump")
 
     # Create Fraud Detection Graph
     adbdgl_adapter.db().delete_graph("fraud-detection", ignore_missing=True)
@@ -76,6 +66,18 @@ def pytest_configure(config: Any) -> None:
         ],
     )
 
+def arango_restore(con: Json, path_to_data: str) -> None:
+    restore_prefix = "./assets/" if os.getenv("GITHUB_ACTIONS") else ""
+
+    subprocess.check_call(
+        f'chmod -R 755 ./assets/arangorestore && {restore_prefix}arangorestore \
+            -c none --server.endpoint tcp://{con["hostname"]}:{con["port"]} \
+                --server.username {con["username"]} --server.database {con["dbName"]} \
+                    --server.password {con["password"]} \
+                        --input-directory "{PROJECT_DIR}/{path_to_data}"',
+        cwd=f"{PROJECT_DIR}/tests",
+        shell=True,
+    )
 
 def get_karate_graph() -> DGLGraph:
     return KarateClubDataset()[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,9 @@
-import json
 import os
 import subprocess
-import time
 from pathlib import Path
 
-from arango import ArangoClient
-from arango.database import StandardDatabase
 from dgl import DGLGraph, remove_self_loop
 from dgl.data import KarateClubDataset, MiniGCDataset
-from requests import post
 from torch import ones, rand, tensor, zeros  # type: ignore
 
 from adbdgl_adapter.adapter import ADBDGL_Adapter
@@ -16,35 +11,53 @@ from adbdgl_adapter.typings import Json
 
 PROJECT_DIR = Path(__file__).parent.parent
 
-con: Json
-adbdgl_adapter: ADBDGL_Adapter
-db: StandardDatabase
+
+def pytest_addoption(parser):
+    parser.addoption("--protocol", action="store", default="http")
+    parser.addoption("--host", action="store", default="localhost")
+    parser.addoption("--port", action="store", default="8529")
+    parser.addoption("--dbName", action="store", default="_system")
+    parser.addoption("--username", action="store", default="root")
+    parser.addoption("--password", action="store", default="opensesame")
 
 
-def pytest_sessionstart() -> None:
+def pytest_configure(config) -> None:
     global con
-    con = get_oasis_crendetials()
-    # con = {
-    #     "username": "root",
-    #     "password": "openSesame",
-    #     "hostname": "localhost",
-    #     "port": 8529,
-    #     "protocol": "http",
-    #     "dbName": "_system",
-    # }
-    print_connection_details(con)
-    time.sleep(5)  # Enough for the oasis instance to be ready.
+    con = {
+        "protocol": config.getoption("protocol"),
+        "hostname": config.getoption("host"),
+        "port": config.getoption("port"),
+        "username": config.getoption("username"),
+        "password": config.getoption("password"),
+        "dbName": config.getoption("dbName"),
+    }
+
+    print("----------------------------------------")
+    print(f"{con['protocol']}://{con['hostname']}:{con['port']}")
+    print("Username: " + con["username"])
+    print("Password: " + con["password"])
+    print("Database: " + con["dbName"])
+    print("----------------------------------------")
 
     global adbdgl_adapter
     adbdgl_adapter = ADBDGL_Adapter(con)
 
-    global db
-    url = "https://" + con["hostname"] + ":" + str(con["port"])
-    client = ArangoClient(hosts=url)
-    db = client.db(con["dbName"], con["username"], con["password"], verify=True)
+    ### Restore fraud dataset via arangorestore
+    arango_restore_data_path = "examples/data/fraud_dump"
+    restore_prefix = "./assets/" if os.getenv("GITHUB_ACTIONS") else ""
+    subprocess.check_call(
+        f'chmod -R 755 ./assets/arangorestore && {restore_prefix}arangorestore \
+            -c none --server.endpoint tcp://{con["hostname"]}:{con["port"]} \
+                --server.username {con["username"]} --server.database {con["dbName"]} \
+                    --server.password {con["password"]} \
+                        --input-directory "{PROJECT_DIR}/{arango_restore_data_path}"',
+        cwd=f"{PROJECT_DIR}/tests",
+        shell=True,
+    )
 
-    arango_restore(con, "examples/data/fraud_dump")
-    db.create_graph(
+    ### Create Fraud Detection Graph
+    adbdgl_adapter.db().delete_graph("fraud-detection", ignore_missing=True)
+    adbdgl_adapter.db().create_graph(
         "fraud-detection",
         edge_definitions=[
             {
@@ -59,39 +72,6 @@ def pytest_sessionstart() -> None:
             },
         ],
     )
-
-
-def get_oasis_crendetials() -> Json:
-    url = "https://tutorials.arangodb.cloud:8529/_db/_system/tutorialDB/tutorialDB"
-    request = post(url, data=json.dumps("{}"))
-    if request.status_code != 200:
-        raise Exception("Error retrieving login data.")
-
-    creds: Json = json.loads(request.text)
-    return creds
-
-
-def arango_restore(con: Json, path_to_data: str) -> None:
-    restore_prefix = "./assets/" if os.getenv("GITHUB_ACTIONS") else ""
-
-    subprocess.check_call(
-        f'chmod -R 755 ./assets/arangorestore && {restore_prefix}arangorestore \
-            -c none --server.endpoint http+ssl://{con["hostname"]}:{con["port"]} \
-                --server.username {con["username"]} --server.database {con["dbName"]} \
-                    --server.password {con["password"]} \
-                        --input-directory "{PROJECT_DIR}/{path_to_data}"',
-        cwd=f"{PROJECT_DIR}/tests",
-        shell=True,
-    )
-
-
-def print_connection_details(con: Json) -> None:
-    print("----------------------------------------")
-    print("https://{}:{}".format(con["hostname"], con["port"]))
-    print("Username: " + con["username"])
-    print("Password: " + con["password"])
-    print("Database: " + con["dbName"])
-    print("----------------------------------------")
 
 
 def get_karate_graph() -> DGLGraph:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
+from typing import Any
 
 from dgl import DGLGraph, remove_self_loop
 from dgl.data import KarateClubDataset, MiniGCDataset
@@ -9,10 +10,12 @@ from torch import ones, rand, tensor, zeros  # type: ignore
 from adbdgl_adapter.adapter import ADBDGL_Adapter
 from adbdgl_adapter.typings import Json
 
+con: Json
+adbdgl_adapter: ADBDGL_Adapter
 PROJECT_DIR = Path(__file__).parent.parent
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Any) -> None:
     parser.addoption("--protocol", action="store", default="http")
     parser.addoption("--host", action="store", default="localhost")
     parser.addoption("--port", action="store", default="8529")
@@ -21,7 +24,7 @@ def pytest_addoption(parser):
     parser.addoption("--password", action="store", default="opensesame")
 
 
-def pytest_configure(config) -> None:
+def pytest_configure(config: Any) -> None:
     global con
     con = {
         "protocol": config.getoption("protocol"),
@@ -42,7 +45,7 @@ def pytest_configure(config) -> None:
     global adbdgl_adapter
     adbdgl_adapter = ADBDGL_Adapter(con)
 
-    ### Restore fraud dataset via arangorestore
+    # Restore fraud dataset via arangorestore
     arango_restore_data_path = "examples/data/fraud_dump"
     restore_prefix = "./assets/" if os.getenv("GITHUB_ACTIONS") else ""
     subprocess.check_call(
@@ -55,7 +58,7 @@ def pytest_configure(config) -> None:
         shell=True,
     )
 
-    ### Create Fraud Detection Graph
+    # Create Fraud Detection Graph
     adbdgl_adapter.db().delete_graph("fraud-detection", ignore_missing=True)
     adbdgl_adapter.db().create_graph(
         "fraud-detection",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def pytest_addoption(parser: Any) -> None:
     parser.addoption("--port", action="store", default="8529")
     parser.addoption("--dbName", action="store", default="_system")
     parser.addoption("--username", action="store", default="root")
-    parser.addoption("--password", action="store", default="opensesame")
+    parser.addoption("--password", action="store", default="openSesame")
 
 
 def pytest_configure(config: Any) -> None:


### PR DESCRIPTION
* Closes #11 

### Additional Changes
* Publicize the `db` instance variable of the `ADBDGL_Adapter` for easy access
* Solve a minor `mypy` issue regarding implicit reexports ([issue](https://github.com/arangoml/dgl-adapter/runs/6261865484?check_suite_focus=true) - [fix](https://github.com/arangoml/dgl-adapter/pull/12/files#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52R32))
* Update README
* Bump `python-arango` & `torch` versions

### Before/After results

Local testing
* Before: ~40 seconds
* After: ~3 seconds (not taking into account the time needed to create an ArangoDB instance with a method of choice)

Github Actions `build.yml` Sequence
* Before: ~5-6 minutes
* After: ~2 minutes