### PR TITLE
Expose ArangoClient & StandardDatabase from adapter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run mypy
         run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run pytest
-        run: py.test --cov=${{env.PACKAGE_DIR}} --cov-report xml -v --color=yes --no-cov-on-fail --code-highlight=yes
+        run: py.test --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
       - name: Publish to coveralls.io
         if: matrix.python == '3.8'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Set up ArangoDB Instance via Docker
-        run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=openSesame arangodb/arangodb:3.9.1
+        run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD= arangodb/arangodb:3.9.1
       - name: Start ArangoDB Instance
         run: docker start adb
       - name: Setup pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: Set up ArangoDB Instance via Docker
+        run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=openSesame arangodb/arangodb:3.9.1
+      - name: Start ArangoDB Instance
+        run: docker start adb
       - name: Setup pip
         run: python -m pip install --upgrade pip setuptools wheel
       - name: Install packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run mypy
         run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run pytest
-        run: py.test --cov=${{env.PACKAGE_DIR}} --cov-report xml -v --color=yes --no-cov-on-fail --code-highlight=yes
+        run: py.test --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
       - name: Publish to coveralls.io
         if: matrix.python == '3.8'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Set up ArangoDB Instance via Docker
-        run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=openSesame arangodb/arangodb:3.9.1
+        run: docker create --name adb -p 8529:8529 -e ARANGO_ROOT_PASSWORD= arangodb/arangodb:3.9.1
       - name: Start ArangoDB Instance
         run: docker start adb
       - name: Setup pip

--- a/README.md
+++ b/README.md
@@ -104,5 +104,5 @@ def pytest_addoption(parser):
     parser.addoption("--url", action="store", default="http://localhost:8529")
     parser.addoption("--dbName", action="store", default="_system")
     parser.addoption("--username", action="store", default="root")
-    parser.addoption("--password", action="store", default="openSesame")
+    parser.addoption("--password", action="store", default="")
 ```

--- a/README.md
+++ b/README.md
@@ -37,36 +37,31 @@ pip install adbdgl-adapter
 
 For a more detailed walk-through, access the official notebook on Colab: <a href="https://colab.research.google.com/github/arangoml/dgl-adapter/blob/master/examples/ArangoDB_DGL_Adapter.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
-
 ```py
 # Import the ArangoDB-DGL Adapter
 from adbdgl_adapter.adapter import ADBDGL_Adapter
 
+# Import the Python-Arango driver
+from arango import ArangoClient
+
 # Import a sample graph from DGL
 from dgl.data import KarateClubDataset
 
-# Store ArangoDB endpoint connection info
-# Assumption: the ArangoDB "fraud detection" dataset is imported to this endpoint for example purposes
-con = {
-    "protocol": "http",
-    "hostname": "localhost",
-    "port": 8529,
-    "username": "root",
-    "password": "openSesame",
-    "dbName": "_system",
-}
+# Instantiate driver client based on user preference
+# Let's assume that the ArangoDB "fraud detection" dataset is imported to this endpoint for example purposes
+db = ArangoClient(hosts="http://localhost:8529").db("_system", username="root", password="openSesame")
 
-# Instantiate the ADBDGL Adapter with connection credentials
-adbdgl_adapter = ADBDGL_Adapter(con)
+# Instantiate the ADBDGL Adapter with driver client
+adbdgl_adapter = ADBDGL_Adapter(db)
 
 # Convert ArangoDB to DGL via Graph Name
 dgl_fraud_graph = adbdgl_adapter.arangodb_graph_to_dgl("fraud-detection")
 
 # Convert ArangoDB to DGL via Collection Names
 dgl_fraud_graph_2 = adbdgl_adapter.arangodb_collections_to_dgl(
-        "fraud-detection", 
-        {"account", "Class", "customer"}, # Specify vertex collections
-        {"accountHolder", "Relationship", "transaction"}, # Specify edge collections
+    "fraud-detection",
+    {"account", "Class", "customer"},  # Specify vertex collections
+    {"accountHolder", "Relationship", "transaction"},  # Specify edge collections
 )
 
 # Convert ArangoDB to DGL via a Metagraph
@@ -94,16 +89,14 @@ Prerequisite: `arangorestore`
 1. `git clone https://github.com/arangoml/dgl-adapter.git`
 2. `cd dgl-adapter`
 3. (create virtual environment of choice)
-4. `pip install -e . pytest`
+4. `pip install -e .[dev]`
 5. (create an ArangoDB instance with method of choice)
-6. `pytest --protocol <> --host <> --port <> --dbName <> --username <> --password <>`
+6. `pytest --url <> --dbName <> --username <> --password <>`
 
 **Note**: A `pytest` parameter can be omitted if the endpoint is using its default value:
 ```python
 def pytest_addoption(parser):
-    parser.addoption("--protocol", action="store", default="http")
-    parser.addoption("--host", action="store", default="localhost")
-    parser.addoption("--port", action="store", default="8529")
+    parser.addoption("--url", action="store", default="http://localhost:8529")
     parser.addoption("--dbName", action="store", default="_system")
     parser.addoption("--username", action="store", default="root")
     parser.addoption("--password", action="store", default="openSesame")

--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ The Deep Graph Library (DGL) is an easy-to-use, high performance and scalable Py
 
 ## Installation
 
+#### Latest Release
 ```
 pip install adbdgl-adapter
+```
+#### Current State
+```
+pip install git+https://github.com/arangoml/dgl-adapter.git
 ```
 
 ##  Quickstart

--- a/adbdgl_adapter/abc.py
+++ b/adbdgl_adapter/abc.py
@@ -62,17 +62,8 @@ class Abstract_ADBDGL_Adapter(ABC):
         return [("_N", "_E", "_N")]
 
     @property
-    def CONNECTION_ATRIBS(self) -> Set[str]:
-        return {"hostname", "username", "password", "dbName"}
-
-    @property
     def METAGRAPH_ATRIBS(self) -> Set[str]:
         return {"vertexCollections", "edgeCollections"}
-
-    @property
-    def EDGE_DEFINITION_ATRIBS(self) -> Set[str]:
-        return {"edge_collection", "from_vertex_collections", "to_vertex_collections"}
-
 
 class Abstract_ADBDGL_Controller(ABC):
     def _adb_attribute_to_dgl_feature(self, key: str, col: str, val: Any) -> Any:

--- a/adbdgl_adapter/abc.py
+++ b/adbdgl_adapter/abc.py
@@ -65,6 +65,7 @@ class Abstract_ADBDGL_Adapter(ABC):
     def METAGRAPH_ATRIBS(self) -> Set[str]:
         return {"vertexCollections", "edgeCollections"}
 
+
 class Abstract_ADBDGL_Controller(ABC):
     def _adb_attribute_to_dgl_feature(self, key: str, col: str, val: Any) -> Any:
         raise NotImplementedError  # pragma: no cover

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -4,7 +4,6 @@
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Set, Union
 
-from arango import ArangoClient
 from arango.cursor import Cursor
 from arango.database import StandardDatabase
 from arango.graph import Graph as ArangoDBGraph
@@ -23,8 +22,8 @@ from .typings import ArangoMetagraph, DGLCanonicalEType, DGLDataDict, Json
 class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
     """ArangoDB-DGL adapter.
 
-    :param conn: Connection details to an ArangoDB instance.
-    :type conn: adbdgl_adapter.typings.Json
+    :param db: A python-arango database instance
+    :type db: arango.database.StandardDatabase
     :param controller: The ArangoDB-DGL controller, for controlling how
         ArangoDB attributes are converted into DGL features, and vice-versa.
         Optionally re-defined by the user if needed (otherwise defaults to
@@ -35,27 +34,17 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
 
     def __init__(
         self,
-        conn: Json,
+        db: StandardDatabase,
         controller: ADBDGL_Controller = ADBDGL_Controller(),
     ):
-        self.__validate_attributes("connection", set(conn), self.CONNECTION_ATRIBS)
         if issubclass(type(controller), ADBDGL_Controller) is False:
             msg = "controller must inherit from ADBDGL_Controller"
             raise TypeError(msg)
 
-        username: str = conn["username"]
-        password: str = conn["password"]
-        db_name: str = conn["dbName"]
-        host: str = conn["hostname"]
-        protocol: str = conn.get("protocol", "https")
-        port = str(conn.get("port", 8529))
-
-        url = protocol + "://" + host + ":" + port
-
-        print(f"Connecting to {url}")
-        self.__db = ArangoClient(hosts=url).db(db_name, username, password, verify=True)
+        self.__db = db
         self.__cntrl: ADBDGL_Controller = controller
 
+    @property
     def db(self) -> StandardDatabase:
         return self.__db
 

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Set, Union
 
 from arango.cursor import Cursor
-from arango.database import StandardDatabase
+from arango.database import Database
 from arango.graph import Graph as ArangoDBGraph
 from arango.result import Result
 from dgl import DGLGraph, heterograph
@@ -23,7 +23,7 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
     """ArangoDB-DGL adapter.
 
     :param db: A python-arango database instance
-    :type db: arango.database.StandardDatabase
+    :type db: arango.database.Database
     :param controller: The ArangoDB-DGL controller, for controlling how
         ArangoDB attributes are converted into DGL features, and vice-versa.
         Optionally re-defined by the user if needed (otherwise defaults to
@@ -34,18 +34,22 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
 
     def __init__(
         self,
-        db: StandardDatabase,
+        db: Database,
         controller: ADBDGL_Controller = ADBDGL_Controller(),
     ):
+        if issubclass(type(db), Database) is False:
+            msg = "**db** parameter must inherit from arango.database.Database"
+            raise TypeError(msg)
+
         if issubclass(type(controller), ADBDGL_Controller) is False:
-            msg = "controller must inherit from ADBDGL_Controller"
+            msg = "**controller** parameter must inherit from ADBDGL_Controller"
             raise TypeError(msg)
 
         self.__db = db
         self.__cntrl: ADBDGL_Controller = controller
 
     @property
-    def db(self) -> StandardDatabase:
+    def db(self) -> Database:
         return self.__db
 
     def arangodb_to_dgl(

--- a/examples/ArangoDB_DGL_Adapter.ipynb
+++ b/examples/ArangoDB_DGL_Adapter.ipynb
@@ -34,7 +34,7 @@
     "id": "bpvZS-1aeG89"
    },
    "source": [
-    "Version: 2.0.0\n",
+    "Version: 1.0.2\n",
     "\n",
     "Objective: Export Graphs from [ArangoDB](https://www.arangodb.com/), a multi-model Graph Database, to [Deep Graph Library](https://www.dgl.ai/) (DGL), a python package for graph neural networks, and vice-versa."
    ]
@@ -58,9 +58,9 @@
    "source": [
     "%%capture\n",
     "!git clone -b oasis_connector --single-branch https://github.com/arangodb/interactive_tutorials.git\n",
-    "!git clone -b 2.0.0 --single-branch https://github.com/arangoml/dgl-adapter.git\n",
+    "!git clone -b 1.0.2 --single-branch https://github.com/arangoml/dgl-adapter.git\n",
     "!rsync -av interactive_tutorials/ ./ --exclude=.git\n",
-    "!pip3 install adbdgl_adapter==2.0.0\n",
+    "!pip3 install adbdgl_adapter==1.0.2\n",
     "!pip3 install matplotlib\n",
     "!pip3 install pyArango\n",
     "!pip3 install networkx ## For drawing purposes "
@@ -85,8 +85,6 @@
     "import dgl\n",
     "import torch\n",
     "import networkx as nx\n",
-    "\n",
-    "from arango import ArangoClient\n",
     "\n",
     "from dgl import remove_self_loop\n",
     "from dgl.data import KarateClubDataset\n",
@@ -331,7 +329,7 @@
     "con = oasis.getTempCredentials()\n",
     "\n",
     "# Connect to the db via the python-arango driver\n",
-    "db = ArangoClient(hosts=f\"https://{con['hostname']}:{con['port']}\").db(con[\"dbName\"], con[\"username\"], con[\"password\"])\n",
+    "db = oasis.connect_python_arango(con)\n",
     "\n",
     "print('\\n--------------------')\n",
     "print(\"https://{}:{}\".format(con[\"hostname\"], con[\"port\"]))\n",
@@ -396,7 +394,7 @@
     "id": "kGfhzPT9eG9A"
    },
    "source": [
-    "Instantiate the ArangoDB-DGL Adapter with the database driver client:"
+    "Connect the ArangoDB-DGL Adapter to our temporary ArangoDB cluster:"
    ]
   },
   {
@@ -411,7 +409,7 @@
    },
    "outputs": [],
    "source": [
-    "adbdgl_adapter = ADBDGL_Adapter(db)"
+    "adbdgl_adapter = ADBDGL_Adapter(con)"
    ]
   },
   {

--- a/examples/ArangoDB_DGL_Adapter.ipynb
+++ b/examples/ArangoDB_DGL_Adapter.ipynb
@@ -34,7 +34,7 @@
     "id": "bpvZS-1aeG89"
    },
    "source": [
-    "Version: 1.0.2\n",
+    "Version: 2.0.0\n",
     "\n",
     "Objective: Export Graphs from [ArangoDB](https://www.arangodb.com/), a multi-model Graph Database, to [Deep Graph Library](https://www.dgl.ai/) (DGL), a python package for graph neural networks, and vice-versa."
    ]
@@ -58,9 +58,9 @@
    "source": [
     "%%capture\n",
     "!git clone -b oasis_connector --single-branch https://github.com/arangodb/interactive_tutorials.git\n",
-    "!git clone -b 1.0.2 --single-branch https://github.com/arangoml/dgl-adapter.git\n",
+    "!git clone -b 2.0.0 --single-branch https://github.com/arangoml/dgl-adapter.git\n",
     "!rsync -av interactive_tutorials/ ./ --exclude=.git\n",
-    "!pip3 install adbdgl_adapter==1.0.2\n",
+    "!pip3 install adbdgl_adapter==2.0.0\n",
     "!pip3 install matplotlib\n",
     "!pip3 install pyArango\n",
     "!pip3 install networkx ## For drawing purposes "
@@ -85,6 +85,8 @@
     "import dgl\n",
     "import torch\n",
     "import networkx as nx\n",
+    "\n",
+    "from arango import ArangoClient\n",
     "\n",
     "from dgl import remove_self_loop\n",
     "from dgl.data import KarateClubDataset\n",
@@ -329,7 +331,7 @@
     "con = oasis.getTempCredentials()\n",
     "\n",
     "# Connect to the db via the python-arango driver\n",
-    "db = oasis.connect_python_arango(con)\n",
+    "db = ArangoClient(hosts=f\"https://{con['hostname']}:{con['port']}\").db(con[\"dbName\"], con[\"username\"], con[\"password\"])\n",
     "\n",
     "print('\\n--------------------')\n",
     "print(\"https://{}:{}\".format(con[\"hostname\"], con[\"port\"]))\n",
@@ -394,7 +396,7 @@
     "id": "kGfhzPT9eG9A"
    },
    "source": [
-    "Connect the ArangoDB-DGL Adapter to our temporary ArangoDB cluster:"
+    "Instantiate the ArangoDB-DGL Adapter with the database driver client:"
    ]
   },
   {
@@ -409,7 +411,7 @@
    },
    "outputs": [],
    "source": [
-    "adbdgl_adapter = ADBDGL_Adapter(con)"
+    "adbdgl_adapter = ADBDGL_Adapter(db)"
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     python_requires=">=3.6",
     license="Apache Software License",
     install_requires=[
+        "requests>=2.27.1",
         "dgl==0.6.1",
         "torch>=1.10.2",
         "python-arango>=7.3.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def pytest_addoption(parser: Any) -> None:
     parser.addoption("--url", action="store", default="http://localhost:8529")
     parser.addoption("--dbName", action="store", default="_system")
     parser.addoption("--username", action="store", default="root")
-    parser.addoption("--password", action="store", default="openSesame")
+    parser.addoption("--password", action="store", default="")
 
 
 def pytest_configure(config: Any) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,9 @@ def pytest_configure(config: Any) -> None:
     print("----------------------------------------")
 
     global adbdgl_adapter
-    db = ArangoClient(hosts=con["url"]).db(con["dbName"], con["username"], con["password"])
+    db = ArangoClient(hosts=con["url"]).db(
+        con["dbName"], con["username"], con["password"]
+    )
     adbdgl_adapter = ADBDGL_Adapter(db)
 
     # Restore fraud dataset via arangorestore
@@ -67,7 +69,7 @@ def pytest_configure(config: Any) -> None:
 
 def arango_restore(con: Json, path_to_data: str) -> None:
     restore_prefix = "./assets/" if os.getenv("GITHUB_ACTIONS") else ""
-    tcp_url = 'tcp://' + con['url'].partition('://')[-1]
+    tcp_url = "tcp://" + con["url"].partition("://")[-1]
 
     subprocess.check_call(
         f'chmod -R 755 ./assets/arangorestore && {restore_prefix}arangorestore \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,8 +77,8 @@ def arango_restore(con: Json, path_to_data: str) -> None:
     subprocess.check_call(
         f'chmod -R 755 ./assets/arangorestore && {restore_prefix}arangorestore \
             -c none --server.endpoint {url} --server.username {con["username"]} \
-                            --server.database {con["dbName"]} --server.password {con["password"]} \
-                                --input-directory "{PROJECT_DIR}/{path_to_data}"',
+                --server.database {con["dbName"]} --server.password {con["password"]} \
+                    --input-directory "{PROJECT_DIR}/{path_to_data}"',
         cwd=f"{PROJECT_DIR}/tests",
         shell=True,
     )

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -12,7 +12,7 @@ from adbdgl_adapter.typings import ArangoMetagraph
 
 from .conftest import (
     adbdgl_adapter,
-    con,
+    db,
     get_clique_graph,
     get_hypercube_graph,
     get_karate_graph,
@@ -26,12 +26,17 @@ def test_validate_attributes() -> None:
         adbdgl_adapter.arangodb_to_dgl("graph_name", bad_metagraph)
 
 
-def test_validate_controller_class() -> None:
+def test_validate_constructor() -> None:
+    bad_db: Dict[str, Any] = dict()
+
     class Bad_ADBDGL_Controller:
         pass
 
     with pytest.raises(TypeError):
-        ADBDGL_Adapter(con, Bad_ADBDGL_Controller())  # type: ignore
+        ADBDGL_Adapter(bad_db, Bad_ADBDGL_Controller())  # type: ignore
+
+    with pytest.raises(TypeError):
+        ADBDGL_Adapter(db, Bad_ADBDGL_Controller())  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,4 +1,4 @@
-from typing import Set, Union
+from typing import Any, Dict, Set, Union
 
 import pytest
 from arango.database import StandardDatabase
@@ -22,7 +22,7 @@ from .conftest import (
 
 def test_validate_attributes() -> None:
     with pytest.raises(ValueError):
-        bad_metagraph = {}
+        bad_metagraph: Dict[str, Any] = dict()
         adbdgl_adapter.arangodb_to_dgl("graph_name", bad_metagraph)
 
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -20,6 +20,12 @@ from .conftest import (
 )
 
 
+def test_validate_attributes() -> None:
+    with pytest.raises(ValueError):
+        bad_metagraph = {}
+        adbdgl_adapter.arangodb_to_dgl("graph_name", bad_metagraph)
+
+
 def test_validate_controller_class() -> None:
     class Bad_ADBDGL_Controller:
         pass

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -19,6 +19,7 @@ from .conftest import (
     get_lollipop_graph,
 )
 
+
 def test_validate_controller_class() -> None:
     class Bad_ADBDGL_Controller:
         pass

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -19,21 +19,6 @@ from .conftest import (
     get_lollipop_graph,
 )
 
-
-def test_validate_attributes() -> None:
-    bad_connection = {
-        "dbName": "_system",
-        "hostname": "localhost",
-        "protocol": "http",
-        "port": 8529,
-        # "username": "root",
-        # "password": "password",
-    }
-
-    with pytest.raises(ValueError):
-        ADBDGL_Adapter(bad_connection)
-
-
 def test_validate_controller_class() -> None:
     class Bad_ADBDGL_Controller:
         pass
@@ -71,7 +56,7 @@ def test_adb_to_dgl(
     adapter: ADBDGL_Adapter, name: str, metagraph: ArangoMetagraph
 ) -> None:
     dgl_g = adapter.arangodb_to_dgl(name, metagraph)
-    assert_dgl_data(adapter.db(), dgl_g, metagraph)
+    assert_dgl_data(adapter.db, dgl_g, metagraph)
 
 
 @pytest.mark.parametrize(
@@ -94,7 +79,7 @@ def test_adb_collections_to_dgl(
         e_cols,
     )
     assert_dgl_data(
-        adapter.db(),
+        adapter.db,
         dgl_g,
         metagraph={
             "vertexCollections": {col: set() for col in v_cols},
@@ -108,13 +93,13 @@ def test_adb_collections_to_dgl(
     [(adbdgl_adapter, "fraud-detection")],
 )
 def test_adb_graph_to_dgl(adapter: ADBDGL_Adapter, name: str) -> None:
-    arango_graph = adapter.db().graph(name)
+    arango_graph = adapter.db.graph(name)
     v_cols = arango_graph.vertex_collections()
     e_cols = {col["edge_collection"] for col in arango_graph.edge_definitions()}
 
     dgl_g: DGLGraph = adapter.arangodb_graph_to_dgl(name)
     assert_dgl_data(
-        adapter.db(),
+        adapter.db,
         dgl_g,
         metagraph={
             "vertexCollections": {col: set() for col in v_cols},


### PR DESCRIPTION
Closes #13

## What's new
* The `con` constructor parameter is now replaced with a `db` parameter, of type [Database](https://github.com/ArangoDB-Community/python-arango/blob/main/arango/database.py#L100)
* Updated README
* Updated test cases