### PR TITLE
new: adjust DGL to ArangoDB interface for increased accessibility

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -52,7 +52,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -66,4 +66,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run mypy
         run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run pytest
-        run: py.test --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
+        run: py.test -s --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
       - name: Publish to coveralls.io
         if: matrix.python == '3.8'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9"]
+        python: ["3.7", "3.8", "3.9"]
     name: Python ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9"]
+        python: ["3.7", "3.8", "3.9"]
     name: Python ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <a href="https://www.arangodb.com/" rel="arangodb.com">![](https://raw.githubusercontent.com/arangoml/dgl-adapter/master/examples/assets/adb_logo.png)</a>
 <a href="https://www.dgl.ai/" rel="dgl.ai"><img src="https://raw.githubusercontent.com/arangoml/dgl-adapter/master/examples/assets/dgl_logo.png" width=40% /></a>
 
-The ArangoDB-DGL Adapter exports Graphs from ArangoDB, a multi-model Graph Database, into Deep Graph Library (DGL), a python package for graph neural networks, and vice-versa.
+The ArangoDB-DGL Adapter exports Graphs from ArangoDB, the multi-model database for graph & beyond, into Deep Graph Library (DGL), a python package for graph neural networks, and vice-versa.
 
 
 ## About DGL

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ from dgl.data import KarateClubDataset
 
 # Instantiate driver client based on user preference
 # Let's assume that the ArangoDB "fraud detection" dataset is imported to this endpoint for example purposes
-db = ArangoClient(hosts="http://localhost:8529").db("_system", username="root", password="openSesame")
+db = ArangoClient(hosts="http://localhost:8529").db("_system", username="root", password="")
 
 # Instantiate the ADBDGL Adapter with driver client
 adbdgl_adapter = ADBDGL_Adapter(db)

--- a/README.md
+++ b/README.md
@@ -45,33 +45,25 @@ pip install git+https://github.com/arangoml/dgl-adapter.git
 Also available as an ArangoDB Lunch & Learn session: [Graph & Beyond Course #2.8](https://www.arangodb.com/resources/lunch-sessions/graph-beyond-lunch-break-2-8-dgl-adapter/)
 
 ```py
-# Import the ArangoDB-DGL Adapter
-from adbdgl_adapter import ADBDGL_Adapter
+from arango import ArangoClient  # Python-Arango driver
+from dgl.data import KarateClubDataset # Sample graph from DGL
 
-# Import the Python-Arango driver
-from arango import ArangoClient
-
-# Import a sample graph from DGL
-from dgl.data import KarateClubDataset
-
-# Instantiate driver client based on user preference
-# Let's assume that the ArangoDB "fraud detection" dataset is imported to this endpoint for example purposes
+# Let's assume that the ArangoDB "fraud detection" dataset is imported to this endpoint
 db = ArangoClient(hosts="http://localhost:8529").db("_system", username="root", password="")
 
-# Instantiate the ADBDGL Adapter with driver client
 adbdgl_adapter = ADBDGL_Adapter(db)
 
-# Convert ArangoDB to DGL via Graph Name
+# Use Case 1.1: ArangoDB to DGL via Graph name
 dgl_fraud_graph = adbdgl_adapter.arangodb_graph_to_dgl("fraud-detection")
 
-# Convert ArangoDB to DGL via Collection Names
+# Use Case 1.2: ArangoDB to DGL via Collection names
 dgl_fraud_graph_2 = adbdgl_adapter.arangodb_collections_to_dgl(
     "fraud-detection",
-    {"account", "Class", "customer"},  # Specify vertex collections
-    {"accountHolder", "Relationship", "transaction"},  # Specify edge collections
+    {"account", "Class", "customer"},  # Vertex collections
+    {"accountHolder", "Relationship", "transaction"},  # Edge collections
 )
 
-# Convert ArangoDB to DGL via a Metagraph
+# Use Case 1.3: ArangoDB to DGL via Metagraph
 metagraph = {
     "vertexCollections": {
         "account": {"Balance", "account_type", "customer_id", "rank"},
@@ -84,7 +76,7 @@ metagraph = {
 }
 dgl_fraud_graph_3 = adbdgl_adapter.arangodb_to_dgl("fraud-detection", metagraph)
 
-# Convert DGL to ArangoDB
+# Use Case 2: DGL to ArangoDB
 dgl_karate_graph = KarateClubDataset()[0]
 adb_karate_graph = adbdgl_adapter.dgl_to_arangodb("Karate", dgl_karate_graph)
 ```

--- a/adbdgl_adapter/abc.py
+++ b/adbdgl_adapter/abc.py
@@ -30,7 +30,11 @@ class Abstract_ADBDGL_Adapter(ABC):
         raise NotImplementedError  # pragma: no cover
 
     def dgl_to_arangodb(
-        self, name: str, dgl_g: Union[DGLGraph, DGLHeteroGraph], batch_size: int
+        self,
+        name: str,
+        dgl_g: Union[DGLGraph, DGLHeteroGraph],
+        overwrite_graph: bool = False,
+        **import_options: Any,
     ) -> ArangoDBGraph:
         raise NotImplementedError  # pragma: no cover
 
@@ -46,9 +50,6 @@ class Abstract_ADBDGL_Adapter(ABC):
         raise NotImplementedError  # pragma: no cover
 
     def __prepare_adb_attributes(self) -> None:
-        raise NotImplementedError  # pragma: no cover
-
-    def __insert_adb_docs(self) -> None:
         raise NotImplementedError  # pragma: no cover
 
     def __fetch_adb_docs(self) -> None:

--- a/adbdgl_adapter/abc.py
+++ b/adbdgl_adapter/abc.py
@@ -54,16 +54,9 @@ class Abstract_ADBDGL_Adapter(ABC):
     def __fetch_adb_docs(self) -> None:
         raise NotImplementedError  # pragma: no cover
 
-    def __validate_attributes(self) -> None:
-        raise NotImplementedError  # pragma: no cover
-
     @property
     def DEFAULT_CANONICAL_ETYPE(self) -> List[DGLCanonicalEType]:
         return [("_N", "_E", "_N")]
-
-    @property
-    def METAGRAPH_ATRIBS(self) -> Set[str]:
-        return {"vertexCollections", "edgeCollections"}
 
 
 class Abstract_ADBDGL_Controller(ABC):

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -102,7 +102,6 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
         }
         """
         logger.debug(f"Starting arangodb_to_dgl({name}, ...):")
-        self.__validate_attributes("graph", set(metagraph), self.METAGRAPH_ATRIBS)
 
         # Maps ArangoDB vertex IDs to DGL node IDs
         adb_map: Dict[str, Dict[str, Any]] = dict()
@@ -502,22 +501,3 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
         """
 
         return self.__db.aql.execute(aql, **query_options)
-
-    def __validate_attributes(
-        self, type: str, attributes: Set[str], valid_attributes: Set[str]
-    ) -> None:
-        """Validates that a set of attributes includes the required valid
-        attributes.
-
-        :param type: The context of the attribute validation
-            (e.g connection attributes, graph attributes, etc).
-        :type type: str
-        :param attributes: The provided attributes, possibly invalid.
-        :type attributes: Set[str]
-        :param valid_attributes: The valid attributes.
-        :type valid_attributes: Set[str]
-        :raise ValueError: If **valid_attributes** is not a subset of **attributes**
-        """
-        if valid_attributes.issubset(attributes) is False:
-            missing_attributes = valid_attributes - attributes
-            raise ValueError(f"Missing {type} attributes: {missing_attributes}")

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -138,7 +138,7 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
                 from_col.add(from_node["col"])
                 to_col.add(to_node["col"])
                 if len(from_col | to_col) > 2:
-                    raise ValueError( # pragma: no cover
+                    raise ValueError(  # pragma: no cover
                         f"""Can't convert to DGL:
                             too many '_from' & '_to' collections in {e_col}
                         """

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -78,7 +78,8 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
             to DGL, along with their associated attributes to keep.
         :type metagraph: adbdgl_adapter.typings.ArangoMetagraph
         :param query_options: Keyword arguments to specify AQL query options when
-            fetching documents from the ArangoDB instance.
+            fetching documents from the ArangoDB instance. Full parameter list:
+            https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute
         :type query_options: Any
         :return: A DGL Heterograph
         :rtype: dgl.heterograph.DGLHeteroGraph
@@ -181,8 +182,9 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
         :type v_cols: Set[str]
         :param e_cols: A set of ArangoDB edge collections to import to DGL.
         :type e_cols: Set[str]
-        :param query_options: Keyword arguments to specify AQL query options
-            when fetching documents from the ArangoDB instance.
+        :param query_options: Keyword arguments to specify AQL query options when
+            fetching documents from the ArangoDB instance. Full parameter list:
+            https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute
         :type query_options: Any
         :return: A DGL Heterograph
         :rtype: dgl.heterograph.DGLHeteroGraph
@@ -199,8 +201,9 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
 
         :param name: The ArangoDB graph name.
         :type name: str
-        :param query_options: Keyword arguments to specify AQL query options
-            when fetching documents from the ArangoDB instance.
+        :param query_options: Keyword arguments to specify AQL query options when
+            fetching documents from the ArangoDB instance. Full parameter list:
+            https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute
         :type query_options: Any
         :return: A DGL Heterograph
         :rtype: dgl.heterograph.DGLHeteroGraph
@@ -228,8 +231,8 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
             Does not drop associated collections.
         :type overwrite_graph: bool
         :param import_options: Keyword arguments to specify additional
-            parameters for ArangoDB document insertion. See
-            arango.collection.Collection.import_bulk for all options.
+            parameters for ArangoDB document insertion. Full parameter list:
+            https://docs.python-arango.com/en/main/specs.html#arango.collection.Collection.import_bulk
         :type import_options: Any
         :return: The ArangoDB Graph API wrapper.
         :rtype: arango.graph.Graph

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -138,7 +138,7 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
                 from_col.add(from_node["col"])
                 to_col.add(to_node["col"])
                 if len(from_col | to_col) > 2:
-                    raise ValueError(
+                    raise ValueError( # pragma: no cover
                         f"""Can't convert to DGL:
                             too many '_from' & '_to' collections in {e_col}
                         """

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -255,7 +255,7 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
             adb_graph = self.__db.create_graph(name, edge_definitions)
 
         adb_v_cols = adb_graph.vertex_collections()
-        adb_e_cols = [e_d["edge_collection"] for e_d in edge_definitions]
+        adb_e_cols = [e_d["edge_collection"] for e_d in adb_graph.edge_definitions()]
 
         has_one_vcol = len(adb_v_cols) == 1
         has_one_ecol = len(adb_e_cols) == 1

--- a/adbdgl_adapter/adapter.py
+++ b/adbdgl_adapter/adapter.py
@@ -415,9 +415,7 @@ class ADBDGL_Adapter(Abstract_ADBDGL_Adapter):
         for key, col_dict in features_data.items():
             for col, array in col_dict.items():
                 logger.debug(f"Inserting {len(array)} '{key}' features into '{col}'")
-                data[key] = (
-                    tensor(array) if has_one_type else {**data[key], col: tensor(array)}
-                )
+                data[key] = tensor(array) if has_one_type else {col: tensor(array)}
 
     def __prepare_adb_attributes(
         self,

--- a/examples/ArangoDB_DGL_Adapter.ipynb
+++ b/examples/ArangoDB_DGL_Adapter.ipynb
@@ -15,7 +15,7 @@
     "id": "U1d45V4OeG89"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/arangoml/dgl-adapter/blob/2.0.1/examples/ArangoDB_DGL_Adapter.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/arangoml/dgl-adapter/blob/2.1.0/examples/ArangoDB_DGL_Adapter.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -34,7 +34,7 @@
     "id": "bpvZS-1aeG89"
    },
    "source": [
-    "Version: 2.0.0\n",
+    "Version: 2.1.0\n",
     "\n",
     "Objective: Export Graphs from [ArangoDB](https://www.arangodb.com/), a multi-model Graph Database, to [Deep Graph Library](https://www.dgl.ai/) (DGL), a python package for graph neural networks, and vice-versa."
    ]
@@ -57,9 +57,9 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install adbdgl-adapter==2.0.1\n",
+    "!pip install adbdgl-adapter==2.1.0\n",
     "!pip install adb-cloud-connector\n",
-    "!git clone -b 2.0.1 --single-branch https://github.com/arangoml/dgl-adapter.git\n",
+    "!git clone -b 2.1.0 --single-branch https://github.com/arangoml/dgl-adapter.git\n",
     "\n",
     "## For drawing purposes \n",
     "!pip install matplotlib\n",
@@ -466,7 +466,7 @@
     "\n",
     "# You can also provide valid Python-Arango AQL query options to the command above, like such:\n",
     "# dgl_g = aadbdgl_adapter.arangodb_graph_to_dgl(graph_name, ttl=1000, stream=True)\n",
-    "# See more here: https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute\n",
+    "# See the full parameter list at https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute\n",
     "\n",
     "# Show graph data\n",
     "print('\\n--------------------')\n",
@@ -522,7 +522,7 @@
     "\n",
     "# You can also provide valid Python-Arango AQL query options to the command above, like such:\n",
     "# dgl_g = adbdgl_adapter.arangodb_collections_to_dgl(\"fraud-detection\", vertex_collections, edge_collections, ttl=1000, stream=True)\n",
-    "# See more here: https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute\n",
+    "# See the full parameter list at https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute\n",
     "\n",
     "# Show graph data\n",
     "print('\\n--------------------')\n",
@@ -588,7 +588,7 @@
     "\n",
     "# You can also provide valid Python-Arango AQL query options to the command above, like such:\n",
     "# dgl_g = adbdgl_adapter.arangodb_to_dgl(graph_name = 'FraudDetection',  fraud_detection_metagraph, ttl=1000, stream=True)\n",
-    "# See more here: https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute\n",
+    "# See the full parameter list at https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute\n",
     "\n",
     "# Show graph data\n",
     "print('\\n--------------')\n",
@@ -728,10 +728,6 @@
     "# Create DGL Graph from attributes\n",
     "dgl_g = fraud_adbdgl_adapter.arangodb_to_dgl('FraudDetection',  fraud_detection_metagraph)\n",
     "\n",
-    "# You can also provide valid Python-Arango AQL query options to the command above, like such:\n",
-    "# dgl_g = fraud_adbdgl_adapter.arangodb_to_dgl(graph_name = 'FraudDetection',  fraud_detection_metagraph, ttl=1000, stream=True)\n",
-    "# See more here: https://docs.python-arango.com/en/main/specs.html#arango.aql.AQL.execute\n",
-    "\n",
     "# Show graph data\n",
     "print('\\n--------------')\n",
     "print(dgl_g)\n",
@@ -799,6 +795,10 @@
     "\n",
     "# Create the ArangoDB graph\n",
     "adb_karate_graph = adbdgl_adapter.dgl_to_arangodb(name, dgl_karate_graph)\n",
+    "\n",
+    "# You can also provide valid Python-Arango Import Bulk options to the command above, like such:\n",
+    "# adb_karate_graph = adbdgl_adapter.dgl_to_arangodb(name, dgl_karate_graph, batch_size=5, on_duplicate=\"replace\")\n",
+    "# See the full parameter list at https://docs.python-arango.com/en/main/specs.html#arango.collection.Collection.import_bulk\n",
     "\n",
     "print('\\n--------------------')\n",
     "print(\"URL: \" + con[\"url\"])\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "setuptools_scm[toml]>=3.4",
-    "wheel",
-]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "requests>=2.27.1",
         "dgl>=0.6.1",
         "torch>=1.10.2",
-        "python-arango>=7.3.1",
+        "python-arango>=7.4.0",
         "setuptools>=45",
     ],
     extras_require={
@@ -41,7 +41,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "requests>=2.27.1",
         "dgl>=0.6.1",
         "torch>=1.10.2",
-        "python-arango>=7.4.0",
+        "python-arango>=7.4.1",
         "setuptools>=45",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ setup(
     keywords=["arangodb", "dgl", "adapter"],
     packages=["adbdgl_adapter"],
     include_package_data=True,
-    use_scm_version=True,
-    setup_requires=["setuptools_scm"],
     python_requires=">=3.6",
     license="Apache Software License",
     install_requires=[
@@ -23,8 +21,7 @@ setup(
         "dgl>=0.6.1",
         "torch>=1.10.2",
         "python-arango>=7.3.1",
-        "setuptools>=42",
-        "setuptools_scm[toml]>=3.4",
+        "setuptools>=45",
     ],
     extras_require={
         "dev": [

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -122,13 +122,13 @@ def test_adb_graph_to_dgl(adapter: ADBDGL_Adapter, name: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "adapter, name, dgl_g, batch_size",
+    "adapter, name, dgl_g, batch_size, overwrite",
     [
-        (adbdgl_adapter, "Clique", get_clique_graph(), 3),
-        (adbdgl_adapter, "Lollipop", get_lollipop_graph(), 1000),
-        (adbdgl_adapter, "Hypercube", get_hypercube_graph(), 1000),
-        (adbdgl_adapter, "Karate", get_karate_graph(), 1000),
-        (adbdgl_adapter, "Social", get_social_graph(), 1000),
+        (adbdgl_adapter, "Clique", get_clique_graph(), 3, False),
+        (adbdgl_adapter, "Lollipop", get_lollipop_graph(), 1000, False),
+        (adbdgl_adapter, "Hypercube", get_hypercube_graph(), 1000, False),
+        (adbdgl_adapter, "Karate", get_karate_graph(), 1000, False),
+        (adbdgl_adapter, "Social", get_social_graph(), 1000, True),
     ],
 )
 def test_dgl_to_adb(
@@ -136,8 +136,9 @@ def test_dgl_to_adb(
     name: str,
     dgl_g: Union[DGLGraph, DGLHeteroGraph],
     batch_size: int,
+    overwrite: bool,
 ) -> None:
-    adb_g = adapter.dgl_to_arangodb(name, dgl_g, batch_size)
+    adb_g = adapter.dgl_to_arangodb(name, dgl_g, batch_size, overwrite)
     assert_arangodb_data(name, dgl_g, adb_g)
 
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -21,12 +21,6 @@ from .conftest import (
 )
 
 
-def test_validate_attributes() -> None:
-    with pytest.raises(ValueError):
-        bad_metagraph: Dict[str, Any] = dict()
-        adbdgl_adapter.arangodb_to_dgl("graph_name", bad_metagraph)
-
-
 def test_validate_constructor() -> None:
     bad_db: Dict[str, Any] = dict()
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -131,6 +131,13 @@ def test_adb_graph_to_dgl(adapter: ADBDGL_Adapter, name: str) -> None:
             "Hypercube",
             get_hypercube_graph(),
             False,
+            {"batch_size": 1000, "on_duplicate": "replace"},
+        ),
+        (
+            adbdgl_adapter,
+            "Hypercube",
+            get_hypercube_graph(),
+            False,
             {"overwrite": True},
         ),
         (adbdgl_adapter, "Karate", get_karate_graph(), False, {"overwrite": True}),

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -116,23 +116,35 @@ def test_adb_graph_to_dgl(adapter: ADBDGL_Adapter, name: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "adapter, name, dgl_g, batch_size, overwrite",
+    "adapter, name, dgl_g, overwrite_graph, import_options",
     [
-        (adbdgl_adapter, "Clique", get_clique_graph(), 3, False),
-        (adbdgl_adapter, "Lollipop", get_lollipop_graph(), 1000, False),
-        (adbdgl_adapter, "Hypercube", get_hypercube_graph(), 1000, False),
-        (adbdgl_adapter, "Karate", get_karate_graph(), 1000, False),
-        (adbdgl_adapter, "Social", get_social_graph(), 1000, True),
+        (
+            adbdgl_adapter,
+            "Clique",
+            get_clique_graph(),
+            False,
+            {"batch_size": 3, "on_duplicate": "replace"},
+        ),
+        (adbdgl_adapter, "Lollipop", get_lollipop_graph(), False, {"overwrite": True}),
+        (
+            adbdgl_adapter,
+            "Hypercube",
+            get_hypercube_graph(),
+            False,
+            {"overwrite": True},
+        ),
+        (adbdgl_adapter, "Karate", get_karate_graph(), False, {"overwrite": True}),
+        (adbdgl_adapter, "Social", get_social_graph(), True, {"overwrite": True}),
     ],
 )
 def test_dgl_to_adb(
     adapter: ADBDGL_Adapter,
     name: str,
     dgl_g: Union[DGLGraph, DGLHeteroGraph],
-    batch_size: int,
-    overwrite: bool,
+    overwrite_graph: bool,
+    import_options: Any,
 ) -> None:
-    adb_g = adapter.dgl_to_arangodb(name, dgl_g, batch_size, overwrite)
+    adb_g = adapter.dgl_to_arangodb(name, dgl_g, overwrite_graph, **import_options)
     assert_arangodb_data(name, dgl_g, adb_g)
 
 


### PR DESCRIPTION
* Closes #23 
* Minor housekeeping
* Drop "official" 3.6 support


## Demo

### ArangoDB to DGL use cases
```py
dgl_karate_graph = KarateClubDataset()[0]

# Use Case 1: Let ADBDGL_Adapter handle the graph creation
adbdgl_adapter.dgl_to_arangodb("Karate", dgl_karate_graph)

# Use Case 2: Create the graph prior to ArangoDB to DGL call
edge_definitions = [...]
db.create_graph("Karate", edge_definitions, smart = True, disjoint = True, ...)
adbdgl_adapter.dgl_to_arangodb("Karate", dgl_karate_graph)

# Use Case 3: Overwrite the graph due to edge definition modifications
new_dgl_karate_graph = heterograph({("KarateMember", "to", "KarateMember"): (tensor([0, 1]), tensor([1, 2]))})
adbdgl_adapter.dgl_to_arangodb("Karate", new_dgl_karate_graph, overwrite_graph=True)
```

### Keyword arguments for import_bulk

Users can now specify parameters for the [`import_bulk()` API of python-arango](https://docs.python-arango.com/en/main/specs.html#arango.collection.StandardCollection.import_bulk) via kwargs

```py
adbdgl_adapter.dgl_to_arangodb("Karate", dgl_karate_graph, sync=True, on_duplicate="replace", batch_size=50)
```